### PR TITLE
add pkh and vess id validation

### DIFF
--- a/src/components/home/ProfileEditModal.tsx
+++ b/src/components/home/ProfileEditModal.tsx
@@ -89,7 +89,10 @@ export const ProfileEditModal: FC<ProfileEditModalProps> = ({ did, name }) => {
     }
   }
 
-  const hasVESSId = useMemo(() => !!vsUser?.vessId && vsUser?.vessId !== '', [vsUser?.vessId])
+  const hasVESSId = useMemo(
+    () => !!vsUser?.vessId && vsUser?.vessId !== '' && vsUser.vessId !== vsUser.did,
+    [vsUser?.vessId, vsUser?.did],
+  )
   const isAvailableId = async (vessId?: string) => {
     try {
       console.log({ vessId })


### PR DESCRIPTION
`vessId`と`did:pkh`の値が同じ場合はVESS IDの設定ができるようできるようにしました。