### PR TITLE
非公開VC対応

### DIFF
--- a/src/components/identity/IdentityContainer.tsx
+++ b/src/components/identity/IdentityContainer.tsx
@@ -49,7 +49,7 @@ export const IdentityContainer: FC = () => {
               <Tab id='id'>ID</Tab>
             </TabList>
             <TabPanel id='attendance' style={{}}>
-              {formatedCredentials.length > 0 ? (
+              {publicCredentials.length > 0 ? (
                 <EventListFrame>
                   {publicCredentials.map((credential) => (
                     <>
@@ -69,7 +69,7 @@ export const IdentityContainer: FC = () => {
               )}
             </TabPanel>
             <TabPanel id='private' style={{}}>
-              {formatedCredentials.length > 0 ? (
+              {privateCredentials.length > 0 ? (
                 <EventListFrame>
                   {privateCredentials.map((credential) => (
                     <CredItem

--- a/src/components/identity/IdentityContainer.tsx
+++ b/src/components/identity/IdentityContainer.tsx
@@ -44,23 +44,50 @@ export const IdentityContainer: FC = () => {
           >
             <TabList style={{ flex: 0 }}>
               <Tab id='attendance'>デジタル証明</Tab>
+              <Tab id='private'>非公開証明</Tab>
               <Tab id='id'>ID</Tab>
             </TabList>
             <TabPanel id='attendance' style={{}}>
               {formatedCredentials.length > 0 ? (
                 <EventListFrame>
                   {formatedCredentials.map((credential) => (
-                    <CredItem
-                      key={credential.id}
-                      image={credential.image}
-                      name={credential.title}
-                      credId={credential.id}
-                    />
+                    <>
+                      {!credential.hideFromPublic && (
+                        <CredItem
+                          key={credential.id}
+                          image={credential.image}
+                          name={credential.title}
+                          credId={credential.id}
+                        />
+                      )}
+                    </>
                   ))}
                 </EventListFrame>
               ) : (
                 <FlexVertical width='100%' alignItems='center'>
                   <div>証明書はありません。</div>
+                </FlexVertical>
+              )}
+            </TabPanel>
+            <TabPanel id='private' style={{}}>
+              {formatedCredentials.length > 0 ? (
+                <EventListFrame>
+                  {formatedCredentials.map((credential) => (
+                    <>
+                      {credential.hideFromPublic && (
+                        <CredItem
+                          key={credential.id}
+                          image={credential.image}
+                          name={credential.title}
+                          credId={credential.id}
+                        />
+                      )}
+                    </>
+                  ))}
+                </EventListFrame>
+              ) : (
+                <FlexVertical width='100%' alignItems='center'>
+                  <div>非公開証明はありません。</div>
                 </FlexVertical>
               )}
             </TabPanel>

--- a/src/components/identity/IdentityContainer.tsx
+++ b/src/components/identity/IdentityContainer.tsx
@@ -20,7 +20,8 @@ export const IdentityContainer: FC = () => {
   const { ccProfile, ccLoading } = useCcProfile(did)
   const { ensProfile, isInitialLoading: ensLoading } = useENS(originalAddress as `0x${string}`)
   const { lensProfile, lensLoading } = useLensProfile(did)
-  const { formatedCredentials, isInitialLoading } = useVerifiableCredentials(did)
+  const { formatedCredentials, publicCredentials, privateCredentials, isInitialLoading } =
+    useVerifiableCredentials(did)
   const router = useRouter()
   const [tabKey, setTabKey] = useState<Key>('attendance')
 
@@ -50,16 +51,14 @@ export const IdentityContainer: FC = () => {
             <TabPanel id='attendance' style={{}}>
               {formatedCredentials.length > 0 ? (
                 <EventListFrame>
-                  {formatedCredentials.map((credential) => (
+                  {publicCredentials.map((credential) => (
                     <>
-                      {!credential.hideFromPublic && (
-                        <CredItem
-                          key={credential.id}
-                          image={credential.image}
-                          name={credential.title}
-                          credId={credential.id}
-                        />
-                      )}
+                      <CredItem
+                        key={credential.id}
+                        image={credential.image}
+                        name={credential.title}
+                        credId={credential.id}
+                      />
                     </>
                   ))}
                 </EventListFrame>
@@ -72,17 +71,13 @@ export const IdentityContainer: FC = () => {
             <TabPanel id='private' style={{}}>
               {formatedCredentials.length > 0 ? (
                 <EventListFrame>
-                  {formatedCredentials.map((credential) => (
-                    <>
-                      {credential.hideFromPublic && (
-                        <CredItem
-                          key={credential.id}
-                          image={credential.image}
-                          name={credential.title}
-                          credId={credential.id}
-                        />
-                      )}
-                    </>
+                  {privateCredentials.map((credential) => (
+                    <CredItem
+                      key={credential.id}
+                      image={credential.image}
+                      name={credential.title}
+                      credId={credential.id}
+                    />
                   ))}
                 </EventListFrame>
               ) : (

--- a/src/components/profile/ProfileContainer.tsx
+++ b/src/components/profile/ProfileContainer.tsx
@@ -302,7 +302,7 @@ export const ProfileContainer: FC<ProfileContainerProps> = ({ did }) => {
                   最新の証明
                 </Text>
                 <CredList>
-                  {formatedCredentials && formatedCredentials.length > 0 ? (
+                  {publicCredentials && publicCredentials.length > 0 ? (
                     <>
                       {publicCredentials.map((credential, index) => (
                         <>

--- a/src/components/profile/ProfileContainer.tsx
+++ b/src/components/profile/ProfileContainer.tsx
@@ -306,13 +306,15 @@ export const ProfileContainer: FC<ProfileContainerProps> = ({ did }) => {
                     <>
                       {formatedCredentials.map((credential, index) => (
                         <>
-                          <CredItem
-                            key={`${credential.id}-${index}`}
-                            image={credential.image}
-                            name={credential.title}
-                            credId={credential.id}
-                            width={'100%'}
-                          />
+                          {!credential.hideFromPublic && (
+                            <CredItem
+                              key={`${credential.id}-${index}`}
+                              image={credential.image}
+                              name={credential.title}
+                              credId={credential.id}
+                              width={'100%'}
+                            />
+                          )}
                         </>
                       ))}
                     </>

--- a/src/components/profile/ProfileContainer.tsx
+++ b/src/components/profile/ProfileContainer.tsx
@@ -58,7 +58,7 @@ export const ProfileContainer: FC<ProfileContainerProps> = ({ did }) => {
   const { openModal } = useModal()
   const { ccProfile } = useCcProfile(did)
   const { ensProfile } = useENS(getAddressFromPkh(did) as `0x${string}`)
-  const { formatedCredentials } = useVerifiableCredentials(did)
+  const { formatedCredentials, publicCredentials } = useVerifiableCredentials(did)
   const { openNavigation } = useNCLayoutContext()
   const { matches } = useBreakpoint()
   const { shareLink } = useShareLink(undefined)
@@ -304,17 +304,15 @@ export const ProfileContainer: FC<ProfileContainerProps> = ({ did }) => {
                 <CredList>
                   {formatedCredentials && formatedCredentials.length > 0 ? (
                     <>
-                      {formatedCredentials.map((credential, index) => (
+                      {publicCredentials.map((credential, index) => (
                         <>
-                          {!credential.hideFromPublic && (
-                            <CredItem
-                              key={`${credential.id}-${index}`}
-                              image={credential.image}
-                              name={credential.title}
-                              credId={credential.id}
-                              width={'100%'}
-                            />
-                          )}
+                          <CredItem
+                            key={`${credential.id}-${index}`}
+                            image={credential.image}
+                            name={credential.title}
+                            credId={credential.id}
+                            width={'100%'}
+                          />
                         </>
                       ))}
                     </>

--- a/src/hooks/useVerifiableCredentials.ts
+++ b/src/hooks/useVerifiableCredentials.ts
@@ -30,6 +30,7 @@ export const useVerifiableCredentials = (did?: string) => {
           ...plainCredential,
           credentialType: item.credentialType,
           credId: item.credentialItem?.id,
+          hideFromPublic: item.hideFromPublic,
         }
       })
       .map((item) => {

--- a/src/hooks/useVerifiableCredentials.ts
+++ b/src/hooks/useVerifiableCredentials.ts
@@ -62,8 +62,18 @@ export const useVerifiableCredentials = (did?: string) => {
       .filter((item) => !item.expirationDate || !isExpired(item.expirationDate))
   }, [CredentialsByHolder])
 
+  const publicCredentials = useMemo(() => {
+    return formatedCredentials.filter((item) => !item.hideFromPublic)
+  }, [formatedCredentials])
+
+  const privateCredentials = useMemo(() => {
+    return formatedCredentials.filter((item) => item.hideFromPublic)
+  }, [formatedCredentials])
+
   return {
     isInitialLoading,
     formatedCredentials,
+    publicCredentials,
+    privateCredentials,
   }
 }


### PR DESCRIPTION
- 非公開VCを自分のプロフィールページからも表示しないようにしました
- アイデンティティページに「非公開証明」タブを追加して非公開VCを一覧できるようにしました。
<img width="500" alt="Screenshot 2024-11-17 at 23 04 22" src="https://github.com/user-attachments/assets/f3cf7af9-25ed-4cd2-8877-bb97e3378b3f">
